### PR TITLE
Embed Google Form for contact

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,38 +254,8 @@ window._wpemojiSettings = {"baseUrl":"https:\/\/s.w.org\/images\/core\/emoji\/15
 
 <p class="has-text-align-center">お問い合わせは、下記フォームよりお願いいたします。</p>
 
-
-<div class="wpcf7 no-js" id="wpcf7-f122-o1" lang="ja" dir="ltr" data-wpcf7-id="122">
-<div class="screen-reader-response">
-<p role="status" aria-live="polite" aria-atomic="true">
-</p>
-<ul></ul>
-</div>
-<form action="/?simply_static_page=1#wpcf7-f122-o1" method="post" class="wpcf7-form init" aria-label="コンタクトフォーム" novalidate="novalidate" data-status="init">
-<div style="display: none;">
-<input type="hidden" name="_wpcf7" value="122"><br>
-<input type="hidden" name="_wpcf7_version" value="6.0.1"><br>
-<input type="hidden" name="_wpcf7_locale" value="ja"><br>
-<input type="hidden" name="_wpcf7_unit_tag" value="wpcf7-f122-o1"><br>
-<input type="hidden" name="_wpcf7_container_post" value="0"><br>
-<input type="hidden" name="_wpcf7_posted_data_hash" value="">
-</div>
-<p><label> 氏名<br>
-<span class="wpcf7-form-control-wrap" data-name="your-name"><input size="40" maxlength="400" class="wpcf7-form-control wpcf7-text wpcf7-validates-as-required" autocomplete="name" aria-required="true" aria-invalid="false" value="" type="text" name="your-name"></span> </label>
-</p>
-<p><label> メールアドレス<br>
-<span class="wpcf7-form-control-wrap" data-name="your-email"><input size="40" maxlength="400" class="wpcf7-form-control wpcf7-email wpcf7-validates-as-required wpcf7-text wpcf7-validates-as-email" autocomplete="email" aria-required="true" aria-invalid="false" value="" type="email" name="your-email"></span> </label>
-</p>
-<p><label> 題名<br>
-<span class="wpcf7-form-control-wrap" data-name="your-subject"><input size="40" maxlength="400" class="wpcf7-form-control wpcf7-text wpcf7-validates-as-required" aria-required="true" aria-invalid="false" value="" type="text" name="your-subject"></span> </label>
-</p>
-<p><label> メッセージ本文 (任意)<br>
-<span class="wpcf7-form-control-wrap" data-name="your-message"><textarea cols="40" rows="10" maxlength="2000" class="wpcf7-form-control wpcf7-textarea" aria-invalid="false" name="your-message"></textarea></span> </label>
-</p>
-<p><input class="wpcf7-form-control wpcf7-submit has-spinner" type="submit" value="送信">
-</p>
-<div class="wpcf7-response-output" aria-hidden="true"></div>
-</form>
+<div style="max-width:640px;margin:0 auto;">
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScsLWL4udkOgjYZjihARPSkHHLapGPDMijY0-Z76CfbEiOv_w/viewform?embedded=true" width="100%" height="738" frameborder="0" marginheight="0" marginwidth="0">読み込んでいます…</iframe>
 </div>
 </main>
 


### PR DESCRIPTION
## Summary
- replace contact form with Google Form embed
- center the embedded form to match layout

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689153144944832b9824f169c1b25c75